### PR TITLE
Drop @skyux-sdk/pact peerDependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@pact-foundation/pact-web": "^9.10.0",
     "@pact-foundation/pact": "^9.10.0",
     "@skyux-sdk/builder": "^4.0.0",
-    "@skyux-sdk/pact": "^4.0.0",
+    "@skyux-sdk/pact": "^4.0.0-rc.1",
     "karma": "^5.0.4"
   },
   "dependencies": {


### PR DESCRIPTION
@blackbaud-dangrochmal is in the process of migrating a SPA to skyux4 which uses pacts, and noticed there's no version 4 of `@skyux-sdk/pact`, only a `4.0.0-rc.1` - https://www.npmjs.com/package/@skyux-sdk/pact

This is one possible way to proceed, alternatively we could just publish version 4 of that package if we're satisfied with the current changes in that rc release.

